### PR TITLE
Readme Update

### DIFF
--- a/1-foundations/exercises/FND_KOANS.md
+++ b/1-foundations/exercises/FND_KOANS.md
@@ -13,8 +13,8 @@ Some koans simply need to have the correct answer substituted for an incorrect o
 ### Getting Started
 
 1. Install [.NET Core SDK 1.0](https://www.microsoft.com/net/core). 
-2. Install [Visual Studio Code](https://code.visualstudio.com/), the [Insiders Edition](https://code.visualstudio.com/insiders) is highly recommended.
-3. Clone the repository: `git clone https://github.com/NotMyself/DotNetCoreKoans.git`.
+2. Install [Visual Studio Code](https://code.visualstudio.com/).
+3. Clone the repository: `git clone https://github.com/nashville-software-school/DotNetCoreKoans.git`.
 4. Change directory into the cloned repository `cd DotNetCoreKoans`.
 5. Restore packages: `dotnet restore`.
 6. Open the project in Visual Studio.


### PR DESCRIPTION
Changed the instructions to telling users which repository to clone from. It should be https://github.com/nashville-software-school/DotNetCoreKoans.git
